### PR TITLE
Add compact started projects list

### DIFF
--- a/apps/richardtaylordawson.com/src/app/page.tsx
+++ b/apps/richardtaylordawson.com/src/app/page.tsx
@@ -5,6 +5,7 @@ import { ExperienceList } from "@/components/experience-list";
 import { ProjectSection } from "@/components/project-section";
 import { SectionHeading } from "@/components/section-heading";
 import { SiteShell } from "@/components/site-shell";
+import { StartedProjectsLoadMore } from "@/components/started-projects-load-more";
 import { SocialLinks } from "@/components/social-links";
 import { aboutCopy, businessSites, experience, projects } from "@/lib/site-content";
 import { buildPageMetadata } from "@/lib/seo";
@@ -115,6 +116,7 @@ export default function Home() {
           items={businessSites}
           divided
         />
+        <StartedProjectsLoadMore />
       </section>
     </SiteShell>
   );

--- a/apps/richardtaylordawson.com/src/components/started-projects-load-more.tsx
+++ b/apps/richardtaylordawson.com/src/components/started-projects-load-more.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ExternalLink, Plus } from "lucide-react";
+
+import { startedProjects } from "@/lib/site-content";
+
+const INITIAL_COUNT = 4;
+const STEP_COUNT = 4;
+
+type StartedProject = (typeof startedProjects)[number];
+
+function StartedProjectItem({ project }: { project: StartedProject }) {
+  return (
+    <a
+      href={project.href}
+      target="_blank"
+      rel="noreferrer"
+      className="group grid gap-3 rounded-[8px] border border-white/10 bg-white/[0.035] p-4 transition hover:border-signal-teal/35 hover:bg-white/[0.06] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary sm:grid-cols-[minmax(0,1fr)_auto]"
+      data-reveal="card"
+      aria-label={`${project.title} on GitHub (opens in a new tab)`}
+    >
+      <span>
+        <span className="flex flex-wrap items-center gap-2">
+          <span className="text-base font-semibold text-white">{project.title}</span>
+          <span className="rounded-[8px] border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/58">
+            {project.tag}
+          </span>
+        </span>
+        <span className="mt-2 block max-w-2xl text-sm leading-6 text-white/[0.62]">
+          {project.text}
+        </span>
+      </span>
+      <span className="inline-flex items-center gap-2 self-start text-sm font-medium text-signal-teal sm:justify-self-end">
+        GitHub
+        <ExternalLink className="size-3.5" />
+      </span>
+    </a>
+  );
+}
+
+export function StartedProjectsLoadMore() {
+  const [visibleCount, setVisibleCount] = useState(INITIAL_COUNT);
+  const visibleProjects = useMemo(
+    () => startedProjects.slice(0, visibleCount),
+    [visibleCount],
+  );
+  const hiddenCount = Math.max(startedProjects.length - visibleCount, 0);
+
+  return (
+    <div className="mt-8 border-t border-white/10 pt-6">
+      <div data-reveal="hero">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.18em] text-signal-amber">
+              Started projects
+            </p>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-white/[0.62]">
+              Smaller experiments and early builds from GitHub, kept compact so the polished work stays up front.
+            </p>
+          </div>
+          <p className="text-sm text-white/45">
+            Showing {visibleProjects.length} of {startedProjects.length}
+          </p>
+        </div>
+      </div>
+
+      <div className="motion-stagger mt-6 grid gap-3">
+        {visibleProjects.map((project) => (
+          <StartedProjectItem key={project.href} project={project} />
+        ))}
+      </div>
+
+      {hiddenCount > 0 ? (
+        <div className="mt-5" data-reveal="hero">
+          <button
+            type="button"
+            className="command-link"
+            onClick={() => setVisibleCount((count) => count + STEP_COUNT)}
+          >
+            <Plus className="size-4" />
+            Load {Math.min(hiddenCount, STEP_COUNT)} more
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/richardtaylordawson.com/src/lib/site-content.ts
+++ b/apps/richardtaylordawson.com/src/lib/site-content.ts
@@ -80,6 +80,87 @@ export const businessSites = [
   },
 ];
 
+export const startedProjects = [
+  {
+    title: "Coin",
+    tag: "Objective-C",
+    text: "An iPhone bill-tracking app with a Heroku and Parse Server backend.",
+    href: "https://github.com/richardtaylordawson/coin",
+  },
+  {
+    title: "Chirp",
+    tag: "CSS",
+    text: "A Twitter API and Google Natural Language API experiment for analyzing tweets.",
+    href: "https://github.com/richardtaylordawson/chirp",
+  },
+  {
+    title: "Kaiju Battle Arena",
+    tag: "PHP",
+    text: "A Twilio-powered messaging multiplayer game where players battled their Kaiju by SMS.",
+    href: "https://github.com/richardtaylordawson/kaiju-battle-arena",
+  },
+  {
+    title: "Chat App",
+    tag: "HTML",
+    text: "A chat application built with Pusher ChatKit, Firebase, and a custom front-end.",
+    href: "https://github.com/richardtaylordawson/chat-app",
+  },
+  {
+    title: "Giphy Search",
+    tag: "JavaScript",
+    text: "A small Create React App project for searching Giphy's public API.",
+    href: "https://github.com/richardtaylordawson/giphy-search",
+  },
+  {
+    title: "Snake",
+    tag: "JavaScript",
+    text: "A simple HTML5 Canvas Snake game.",
+    href: "https://github.com/richardtaylordawson/snake",
+  },
+  {
+    title: "Calculator",
+    tag: "JavaScript",
+    text: "A Bootstrap calculator with ES modules and switchable Bootswatch themes.",
+    href: "https://github.com/richardtaylordawson/calculator",
+  },
+  {
+    title: "Gaming Trivia",
+    tag: "JavaScript",
+    text: "A trivia game built with NES.css and open trivia questions.",
+    href: "https://github.com/richardtaylordawson/gaming-trivia",
+  },
+  {
+    title: "Yahtz",
+    tag: "TypeScript",
+    text: "An early TypeScript dice game project.",
+    href: "https://github.com/richardtaylordawson/yahtz",
+  },
+  {
+    title: "Apple Music Activity",
+    tag: "JavaScript",
+    text: "A reporting app for Apple Music listening history using Chart.js, Sass, and Gulp.",
+    href: "https://github.com/richardtaylordawson/apple-music-activity",
+  },
+  {
+    title: "Pingpong Scorekeeper",
+    tag: "Objective-C",
+    text: "An iPhone scorekeeping app for ping pong with portrait and landscape modes.",
+    href: "https://github.com/richardtaylordawson/pingpong-scorekeeper",
+  },
+  {
+    title: "Mahjong",
+    tag: "Java",
+    text: "Object-oriented Mahjong tile modeling in Java, without full game logic.",
+    href: "https://github.com/richardtaylordawson/mahjong",
+  },
+  {
+    title: "Simple Todo",
+    tag: "JavaScript",
+    text: "A simple todo app built with React, Firebase, and Semantic UI.",
+    href: "https://github.com/richardtaylordawson/simple-todo",
+  },
+] as const;
+
 export const experience = [
   {
     company: "AudioEye",


### PR DESCRIPTION
## Summary
- adds started/incomplete GitHub project data to the site
- renders the projects in a compact lower-priority section below the main work
- limits initial space with a Load more control

## Validation
- npm run lint --workspace richardtaylordawson.com
- npm run build --workspace richardtaylordawson.com